### PR TITLE
New definition file

### DIFF
--- a/examples/P5C090.toml
+++ b/examples/P5C090.toml
@@ -1,30 +1,30 @@
-# Example of a definition for a P5C060/EP600
+# Example of a definition for a P5C090/EP900
 
-name = "P5C060/EP600"
+name = "P5C090/EP900"
 
 [pinout]
 # Defines both package structure and number of pins for each side. L, R, in order.
-pins_per_side = [12, 12]
+pins_per_side = [20, 20]
 
 # List of all the pins of the IC, from 1 onward, as mapped on the ZIF42 socket of the dupico
 # note that, in this list, 21 is a placeholder for GND, 42 a placeholder for a power source (which could be 5V or different).
 # These are used to properly draw the map on the interface
-ZIF_map = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 21, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42]
+ZIF_map = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 21, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42]
 
 # List of the pins, as numbered on the IC, that can be used as clock inputs
-clk_pins = [1, 13]
+clk_pins = [1, 21]
 
 # List of the pins, as numbered on the IC, that are input only pins
-in_pins = [2, 11, 14, 23]
+in_pins = [2, 3, 4, 17, 18, 19, 22, 23, 24, 37, 38, 39]
 
 # List of the pins, as numbered on the IC, that are I/O pins (can be configured as inputs or outputs)
-io_pins = [3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 18, 19, 20, 21, 22]
+io_pins = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]
 
 # List of the pins, as numbered on the IC, that are output only
 o_pins = []
 
 # List of the pins, as numbered on the IC, that are registered outputs
-q_pins = [3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 18, 19, 20, 21, 22]
+q_pins = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]
 
 # List of the pins that are active low OE
 oe_l_pins = []
@@ -33,16 +33,16 @@ oe_l_pins = []
 oe_h_pins = []
 
 # List of the pins, as numbered on the IC, that can be used as feedback pins
-f_pins = [3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 18, 19, 20, 21, 22]
+f_pins = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]
 
 # List of the output pins, as numbered on the IC, capable of going HI-Z
-hiz_o_pins = [3, 4, 5, 6, 7, 8, 9, 10, 15, 16, 17, 18, 19, 20, 21, 22]
+hiz_o_pins = [5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]
 
 [adapter]
 # pins that need to be forced high to read this in the adapter
 hi_pins = []
 # Notes on the adapter necessary to read this IC
-notes = "Insert the PAL POD in the dupico, topmost position in socket, and insert the PLD in the ZIF24 socket"
+notes = "Insert the IC in the topmost position on the ZIF42, then connect pin 21 of the ZIF42 to pin 20 of the IC"
 
 [requirements]
 hardware = 3


### PR DESCRIPTION
Added P5C090/EP900 definition.
Device is 40 pins so no POD used.

Noted in P5C060 file that is also covers the EP600 device